### PR TITLE
:wrench: Allow specification of custom timeout for API calls

### DIFF
--- a/kraken.js
+++ b/kraken.js
@@ -6,18 +6,26 @@ var querystring	= require('querystring');
  * KrakenClient connects to the Kraken.com API
  * @param {String} key    API Key
  * @param {String} secret API Secret
- * @param {String} [otp]  Two-factor password (optional) (also, doesn't work)
+ * @param {String|Object} [options={}]  Additional options. If a string is passed, will default to just setting `options.otp`.
+ * @param {String} [options.otp] Two-factor password (optional) (also, doesn't work)
+ * @param {Number} [options.timeout] Maximum timeout (in milliseconds) for all API-calls (passed to `request`)
  */
-function KrakenClient(key, secret, otp) {
+function KrakenClient(key, secret, options) {
 	var self = this;
+
+	// make sure to be backwards compatible
+	options = options || {};
+	if(typeof options === 'string') {
+		options = { otp: options };
+	}
 
 	var config = {
 		url: 'https://api.kraken.com',
 		version: '0',
 		key: key,
 		secret: secret,
-		otp: otp,
-		timeoutMS: 5000
+		otp: options.otp,
+		timeoutMS: options.timeout || 5000
 	};
 
 	/**


### PR DESCRIPTION
Kraken API can be a bit shaky at times and the timeout always defaults
to 5000ms. Adapt the `KrakenClient` constructor to take an
`options`-object instead of just the `otp`-parameter which can also
hold a custom timeout value.

Ensure backwards compatibility by allowing options to be a string
still (which will default to just `options.otp` being set to that
string). Timeout still defaults to 5000ms so the change should be 100%
backwards-compatible.